### PR TITLE
chore: rebrand AdminBro to AdminJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# Expressjs plugin for AdminBro
+# Expressjs plugin for AdminJS
 
-This is an official [AdminBro](https://github.com/SoftwareBrothers/admin-bro) plugin which integrates it to [expressjs](https://expressjs.com/) framework.
+This is an official [AdminJS](https://github.com/SoftwareBrothers/adminjs) plugin which integrates it to [expressjs](https://expressjs.com/) framework.
 
-## AdminBro
+## AdminJS
 
-AdminBro is an automatic admin interface which can be plugged into your application. You, as a developer, provide database models (like posts, comments, stores, products or whatever else your application uses), and AdminBro generates UI which allows you (or other trusted users) to manage content.
+AdminJS is an automatic admin interface which can be plugged into your application. You, as a developer, provide database models (like posts, comments, stores, products or whatever else your application uses), and AdminJS generates UI which allows you (or other trusted users) to manage content.
 
-Check out the example application with mongo and postgres models here: https://admin-bro-example-app-staging.herokuapp.com/admin
+Check out the example application with mongo and postgres models here: https://adminjs-example-app-staging.herokuapp.com/admin
 
-Or visit [AdminBro](https://github.com/SoftwareBrothers/admin-bro) github page.
+Or visit [AdminJS](https://github.com/SoftwareBrothers/adminjs) github page.
 
 ## Usage
 
-To see example usage visit the [Express section under AdminBro project page](https://softwarebrothers.github.io/admin-bro-dev/module-admin-bro-expressjs.html)
+To see example usage visit the [Express section under AdminJS project page](https://softwarebrothers.github.io/adminjs-dev/module-adminjs-expressjs.html)
 
 ## Debugging
-Set `process.env.ADMIN_BRO_EXPRESS_DEBUG` env variable to see debug logs from the library
+Set `process.env.ADMINJS_EXPRESS_DEBUG` env variable to see debug logs from the library
 
 ## License
 
-AdminBro is Copyright © 2018 SoftwareBrothers.co. It is free software and may be redistributed under the terms specified in the [LICENSE](LICENSE) file.
+AdminJS is Copyright © 2021 SoftwareBrothers.co. It is free software and may be redistributed under the terms specified in the [LICENSE](LICENSE) file.
 
 ## About SoftwareBrothers.co
 

--- a/examples/auth.ts
+++ b/examples/auth.ts
@@ -1,13 +1,13 @@
-import AdminBro from "admin-bro";
+import AdminJS from "adminjs";
 import express from "express";
 import mongoose from "mongoose";
-import MongooseAdapter from "@admin-bro/mongoose";
-import AdminBroExpress from "../src";
+import MongooseAdapter from "@adminjs/mongoose";
+import AdminJSExpress from "../src";
 
 import "./mongoose/article-model";
 import "./mongoose/admin-model";
 
-AdminBro.registerAdapter(MongooseAdapter);
+AdminJS.registerAdapter(MongooseAdapter);
 
 const ADMIN = {
   email: "test@example.com",
@@ -20,12 +20,12 @@ const start = async () => {
   );
   const app = express();
 
-  const adminBro = new AdminBro({
+  const adminJs = new AdminJS({
     databases: [connection],
     rootPath: "/admin",
   });
 
-  const router = AdminBroExpress.buildAuthenticatedRouter(adminBro, {
+  const router = AdminJSExpress.buildAuthenticatedRouter(adminJs, {
     authenticate: async (email, password) => {
       if (ADMIN.password === password && ADMIN.email === email) {
         return ADMIN;
@@ -35,10 +35,10 @@ const start = async () => {
     cookiePassword: "somasd1nda0asssjsdhb21uy3g",
   });
 
-  app.use(adminBro.options.rootPath, router);
+  app.use(adminJs.options.rootPath, router);
 
   app.listen(process.env.PORT || 8080, () =>
-    console.log("AdminBro is under localhost:8080/admin")
+    console.log("AdminJS is running under localhost:8080/admin")
   );
 };
 

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -1,13 +1,13 @@
-import AdminBro from "admin-bro";
+import AdminJS from "adminjs";
 import express from "express";
 import mongoose from "mongoose";
-import MongooseAdapter from "@admin-bro/mongoose";
+import MongooseAdapter from "@adminjs/mongoose";
 
-import AdminBroExpress from "../src";
+import AdminJSExpress from "../src";
 import "./mongoose/article-model";
 import "./mongoose/admin-model";
 
-AdminBro.registerAdapter(MongooseAdapter);
+AdminJS.registerAdapter(MongooseAdapter);
 
 const start = async () => {
   const connection = await mongoose.connect(
@@ -16,16 +16,16 @@ const start = async () => {
   );
   const app = express();
 
-  const adminBro = new AdminBro({
+  const adminJs = new AdminJS({
     databases: [connection],
     rootPath: "/admin",
   });
-  const router = AdminBroExpress.buildRouter(adminBro);
+  const router = AdminJSExpress.buildRouter(adminJs);
 
-  app.use(adminBro.options.rootPath, router);
+  app.use(adminJs.options.rootPath, router);
 
   app.listen(process.env.PORT || 8080, () =>
-    console.log("AdminBro is under localhost:8080/admin")
+    console.log("AdminJS is running under localhost:8080/admin")
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/SoftwareBrothers/adminjs-expressjs#readme",
   "peerDependencies": {
-    "adminjs": ">=3.0.0",
+    "adminjs": ">=5.0.0",
     "express": ">=4.16.4",
     "express-formidable": "^1.2.0",
     "express-session": ">=1.15.6"
@@ -41,7 +41,7 @@
     }
   },
   "devDependencies": {
-    "@adminjs/mongoose": "^1.1.0",
+    "@adminjs/mongoose": "^2.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@semantic-release/git": "^9.0.0",
     "@types/express": "^4.17.9",
@@ -52,7 +52,7 @@
     "@types/mongoose": "^5.10.1",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
-    "adminjs": "^3.3.1",
+    "adminjs": "^5.0.0",
     "chai": "^4.2.0",
     "commitlint": "^11.0.0",
     "eslint": "^7.13.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@admin-bro/express",
+  "name": "@adminjs/express",
   "version": "3.1.0",
-  "description": "This is an official AdminBro plugin which integrates it to expressjs framework",
+  "description": "This is an official AdminJS plugin which integrates it with Express.js framework",
   "main": "lib/index.js",
   "scripts": {
     "dev": "rm -rf lib && tsc --watch",
@@ -15,22 +15,22 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SoftwareBrothers/admin-bro-expressjs.git"
+    "url": "git+https://github.com/SoftwareBrothers/adminjs-expressjs.git"
   },
   "keywords": [
     "expressjs",
     "admin",
-    "adminbro",
+    "adminjs",
     "admin-panel"
   ],
   "author": "Michał Laskowski",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
-    "url": "https://github.com/SoftwareBrothers/admin-bro-expressjs/issues"
+    "url": "https://github.com/SoftwareBrothers/adminjs-expressjs/issues"
   },
-  "homepage": "https://github.com/SoftwareBrothers/admin-bro-expressjs#readme",
+  "homepage": "https://github.com/SoftwareBrothers/adminjs-expressjs#readme",
   "peerDependencies": {
-    "admin-bro": ">=3.0.0",
+    "adminjs": ">=3.0.0",
     "express": ">=4.16.4",
     "express-formidable": "^1.2.0",
     "express-session": ">=1.15.6"
@@ -41,7 +41,7 @@
     }
   },
   "devDependencies": {
-    "@admin-bro/mongoose": "^1.1.0",
+    "@adminjs/mongoose": "^1.1.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@semantic-release/git": "^9.0.0",
     "@types/express": "^4.17.9",
@@ -52,7 +52,7 @@
     "@types/mongoose": "^5.10.1",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
-    "admin-bro": "^3.3.1",
+    "adminjs": "^3.3.1",
     "chai": "^4.2.0",
     "commitlint": "^11.0.0",
     "eslint": "^7.13.0",

--- a/src/authentication/login.handler.ts
+++ b/src/authentication/login.handler.ts
@@ -1,8 +1,8 @@
-import AdminBro from "admin-bro";
+import AdminJS from "adminjs";
 import { Router } from "express";
 import { AuthenticationOptions } from "../types";
 
-const getLoginPath = (admin: AdminBro): string => {
+const getLoginPath = (admin: AdminJS): string => {
   const { loginPath, rootPath } = admin.options;
   // since we are inside already namespaced router we have to replace login and logout routes that
   // they don't have rootUrl inside. So changing /admin/login to just /login.
@@ -17,7 +17,7 @@ const getLoginPath = (admin: AdminBro): string => {
 
 export const withLogin = (
   router: Router,
-  admin: AdminBro,
+  admin: AdminJS,
   auth: AuthenticationOptions
 ): void => {
   const { rootPath } = admin.options;

--- a/src/authentication/logout.handler.ts
+++ b/src/authentication/logout.handler.ts
@@ -1,7 +1,7 @@
-import AdminBro from "admin-bro";
+import AdminJS from "adminjs";
 import { Router } from "express";
 
-const getLogoutPath = (admin: AdminBro) => {
+const getLogoutPath = (admin: AdminJS) => {
   const { logoutPath, rootPath } = admin.options;
   const normalizedLogoutPath = logoutPath.replace(rootPath, "");
 
@@ -10,7 +10,7 @@ const getLogoutPath = (admin: AdminBro) => {
     : `/${normalizedLogoutPath}`;
 };
 
-export const withLogout = (router: Router, admin: AdminBro): void => {
+export const withLogout = (router: Router, admin: AdminJS): void => {
   const logoutPath = getLogoutPath(admin);
 
   router.get(logoutPath, async (request, response) => {

--- a/src/authentication/protected-routes.handler.ts
+++ b/src/authentication/protected-routes.handler.ts
@@ -1,9 +1,9 @@
-import AdminBro, { Router as AdminRouter } from "admin-bro";
+import AdminJS, { Router as AdminRouter } from "adminjs";
 import { Router } from "express";
 
 export const withProtectedRoutesHandler = (
   router: Router,
-  admin: AdminBro
+  admin: AdminJS
 ): void => {
   const { rootPath } = admin.options;
 

--- a/src/buildAuthenticatedRouter.ts
+++ b/src/buildAuthenticatedRouter.ts
@@ -1,4 +1,4 @@
-import AdminBro from "admin-bro";
+import AdminJS from "adminjs";
 import express, { Router } from "express";
 import session from "express-session";
 import { withLogout } from "./authentication/logout.handler";
@@ -11,7 +11,7 @@ import formidableMiddleware from "express-formidable";
 
 /**
  * @typedef {Function} Authenticate
- * @memberof module:@admin-bro/express
+ * @memberof module:@adminjs/express
  * @description
  * function taking 2 arguments email and password
  * @param {string} [email]         email given in the form
@@ -27,26 +27,26 @@ import formidableMiddleware from "express-formidable";
  * not optimized for production usage and, in development, it causes
  * logging out after every page refresh (if you use nodemon).
  * @static
- * @memberof module:@admin-bro/express
+ * @memberof module:@adminjs/express
  * @example
  * const ADMIN = {
  *   email: 'test@example.com',
  *   password: 'password',
  * }
  *
- * AdminBroExpress.buildAuthenticatedRouter(adminBro, {
+ * AdminJSExpress.buildAuthenticatedRouter(adminJs, {
  *   authenticate: async (email, password) => {
  *     if (ADMIN.password === password && ADMIN.email === email) {
  *       return ADMIN
  *     }
  *     return null
  *   },
- *   cookieName: 'adminbro',
+ *   cookieName: 'adminjs',
  *   cookiePassword: 'somePassword',
  * }, [router])
  */
 export const buildAuthenticatedRouter = (
-  admin: AdminBro,
+  admin: AdminJS,
   auth: AuthenticationOptions,
   predefinedRouter?: express.Router | null,
   sessionOptions?: session.SessionOptions,
@@ -65,7 +65,7 @@ export const buildAuthenticatedRouter = (
     session({
       ...sessionOptions,
       secret: auth.cookiePassword,
-      name: auth.cookieName || "adminbro",
+      name: auth.cookieName || "adminjs",
     })
   );
   router.use(formidableMiddleware(formidableOptions));

--- a/src/buildRouter.ts
+++ b/src/buildRouter.ts
@@ -1,4 +1,4 @@
-import AdminBro, { Router as AdminRouter } from "admin-bro";
+import AdminJS, { Router as AdminRouter } from "adminjs";
 import { RequestHandler, Router } from "express";
 import formidableMiddleware from "express-formidable";
 import path from "path";
@@ -6,20 +6,20 @@ import { WrongArgumentError } from "./errors";
 import { log } from "./logger";
 import { FormidableOptions } from "./types";
 
-const INVALID_ADMIN_BRO_INSTANCE =
-  "You have to pass an instance of AdminBro to the buildRouter() function";
+const INVALID_ADMINJS_INSTANCE =
+  "You have to pass an instance of AdminJS to the buildRouter() function";
 
 export const buildRouter = (
-  admin: AdminBro,
+  admin: AdminJS,
   predefinedRouter?: Router | null,
   formidableOptions?: FormidableOptions
 ): Router => {
-  if (admin?.constructor?.name !== "AdminBro") {
-    throw new WrongArgumentError(INVALID_ADMIN_BRO_INSTANCE);
+  if (admin?.constructor?.name !== "AdminJS") {
+    throw new WrongArgumentError(INVALID_ADMINJS_INSTANCE);
   }
 
   admin.initialize().then(() => {
-    log.debug("AdminBro: bundle ready");
+    log.debug("AdminJS: bundle ready");
   });
 
   const { routes, assets } = AdminRouter;
@@ -27,7 +27,7 @@ export const buildRouter = (
   router.use(formidableMiddleware(formidableOptions));
 
   routes.forEach((route) => {
-    // we have to change routes defined in AdminBro from {recordId} to :recordId
+    // we have to change routes defined in AdminJS from {recordId} to :recordId
     const expressPath = route.path.replace(/{/g, ":").replace(/}/g, "");
 
     const handler: RequestHandler = async (req, res, next) => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,14 +9,14 @@ export class OldBodyParserUsedError extends Error {
   constructor(
     message = `
   You probably used old \`body-parser\` middleware, which is not compatible
-  with @admin-bro/express. In order to make it work you will have to
-  1. move body-parser invocation after the admin bro setup like this:
+  with @adminjs/express. In order to make it work you will have to
+  1. move body-parser invocation after the AdminJS setup like this:
   
-  const adminBro = new AdminBro()
-  const router = new buildRouter(adminBro)
-  app.use(adminBro.options.rootPath, router)
+  const adminJs = new AdminJS()
+  const router = new buildRouter(adminJs)
+  app.use(adminJs.options.rootPath, router)
   
-  // body parser goes after the AdminBro router
+  // body parser goes after the AdminJS router
   app.use(bodyParser())
   
   2. Upgrade body-parser to the latest version and use it like this:

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,17 +3,17 @@ import { buildAuthenticatedRouter } from "./buildAuthenticatedRouter";
 import { buildRouter } from "./buildRouter";
 
 /**
- * @module @admin-bro/express
+ * @module @adminjs/express
  * @subcategory Plugins
  * @section modules
  *
  * @classdesc
- * Plugin that allows you to add AdminBro to Express.js applications.
+ * Plugin that allows you to add AdminJS to Express.js applications.
  *
  * ## Installation
  *
  * ```sh
- * npm install @admin-bro/express
+ * npm install @adminjs/express
  * ```
  *
  * It has 2 peerDependencies: `express-formidable` and `express`,
@@ -26,44 +26,44 @@ import { buildRouter } from "./buildRouter";
  * ## Usage
  *
  * ```
- * const AdminBroExpress = require('@admin-bro/express')
+ * const AdminJSExpress = require('@adminjs/express')
  * ```
  *
  * It exposes 2 methods that create an Express Router, which can be attached
- * to a given url in the API. Each method takes a pre-configured instance of {@link AdminBro}.
+ * to a given url in the API. Each method takes a pre-configured instance of {@link AdminJS}.
  *
- * - {@link module:@admin-bro/express.buildRouter AdminBroExpress.buildRouter(admin, [predefinedRouter])}
- * - {@link module:@admin-bro/express.buildAuthenticatedRouter AdminBroExpress.buildAuthenticatedRouter(admin, auth, [predefinedRouter], sessionOptions)}
+ * - {@link module:@adminjs/express.buildRouter AdminJSExpress.buildRouter(admin, [predefinedRouter])}
+ * - {@link module:@adminjs/express.buildAuthenticatedRouter AdminJSExpress.buildAuthenticatedRouter(admin, auth, [predefinedRouter], sessionOptions)}
  *
  * If you want to use a router you have already created - not a problem. Just pass it
  * as a `predefinedRouter` parameter.
  *
  * You may want to use this option when you want to include
- * some custom auth middleware for you AdminBro routes.
+ * some custom auth middleware for you AdminJS routes.
  *
  * ## Example without an authentication
  *
  * ```
- * const AdminBro = require('admin-bro')
- * const AdminBroExpress = require('@admin-bro/express')
+ * const AdminJS = require('adminjs')
+ * const AdminJSExpress = require('@adminjs/express')
  *
  * const express = require('express')
  * const app = express()
  *
- * const adminBro = new AdminBro({
+ * const adminJs = new AdminJS({
  *   databases: [],
  *   rootPath: '/admin',
  * })
  *
- * const router = AdminBroExpress.buildRouter(adminBro)
- * app.use(adminBro.options.rootPath, router)
- * app.listen(8080, () => console.log('AdminBro is under localhost:8080/admin'))
+ * const router = AdminJSExpress.buildRouter(adminJs)
+ * app.use(adminJs.options.rootPath, router)
+ * app.listen(8080, () => console.log('AdminJS is running under localhost:8080/admin'))
  * ```
  *
  * ## Using build in authentication
  *
  * To protect the routes with a session authentication, you can use predefined
- * {@link module:@admin-bro/express.buildAuthenticatedRouter} method.
+ * {@link module:@adminjs/express.buildAuthenticatedRouter} method.
  *
  * Note! To use authentication in production environment, there is a need to configure
  * express-session for production build. It can be achieved by passing options to
@@ -81,22 +81,22 @@ import { buildRouter } from "./buildRouter";
  *     req.session.adminUser = req.session.admin
  *     next()
  *   } else {
- *     res.redirect(adminBro.options.loginPath)
+ *     res.redirect(adminJs.options.loginPath)
  *   }
  * })
- * router = AdminBroExpress.buildRouter(adminBro, router)
+ * router = AdminJSExpress.buildRouter(adminJs, router)
  * ```
  *
- * Where `req.session.admin` is {@link AdminBro#CurrentAdmin},
+ * Where `req.session.admin` is {@link AdminJS#CurrentAdmin},
  * meaning that it should have at least an email property.
  */
 
 /**
  * Plugin name
  * @static
- * @memberof module:@admin-bro/express
+ * @memberof module:@adminjs/express
  */
-export const name = "AdminBroExpressjs";
+export const name = "AdminJSExpressjs";
 export { SessionData } from "express-session";
 
 module.exports = { name, buildAuthenticatedRouter, buildRouter };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,9 +1,9 @@
 export const log = {
   /**
-   * Logs the debug message to console if `process.env.ADMIN_BRO_EXPRESS_DEBUG` is set
+   * Logs the debug message to console if `process.env.ADMINJS_EXPRESS_DEBUG` is set
    */
   debug: (message: string): void => {
-    if (process.env.ADMIN_BRO_EXPRESS_DEBUG) {
+    if (process.env.ADMINJS_EXPRESS_DEBUG) {
       console.debug(message);
     }
   },

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,11 +1,11 @@
 import express from "express";
-import AdminBro from "admin-bro";
+import AdminJS from "adminjs";
 import { buildRouter } from "../src/buildRouter";
 
 describe("plugin", () => {
   describe(".buildRouter", () => {
-    it("returns an express router when AdminBro instance given as an argument", () => {
-      expect(buildRouter(new AdminBro())).toBeInstanceOf(
+    it("returns an express router when AdminJS instance given as an argument", () => {
+      expect(buildRouter(new AdminJS())).toBeInstanceOf(
         express.Router().constructor
       );
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "target": "es2017",
     "jsx": "preserve",
     "importHelpers": true,
+    "skipLibCheck": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "strictFunctionTypes": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,13 @@
 # yarn lockfile v1
 
 
-"@admin-bro/design-system@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@admin-bro/design-system/-/design-system-1.7.0.tgz#1a5f46bff89db7aba33367db9a84cf00ddaaea5c"
-  integrity sha512-pf+b/YkKoylvcg1wp1yUhbWv0e5MZHjKQdPqTt6UXutVgpqldimDv5be3i2avkqNSB5XrOXVZTIcW4vj0vy33g==
+"@adminjs/design-system@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@adminjs/design-system/-/design-system-2.0.1.tgz#52468031ee34ffab117f60740924793aa22cce39"
+  integrity sha512-+lBuFGHPISWPC7O1DSEB4Eae3S+vrVS6LD+TZbVju6nvhIUnGZgc3DHv/wLtmTzHwwgnDsEwY7RRMatsN3zuBQ==
   dependencies:
     "@carbon/icons-react" "^10.14.0"
+    date-fns "2.15.0"
     jw-paginate "^1.0.4"
     lodash "^4.17.20"
     polished "^3.6.5"
@@ -15,10 +16,10 @@
     react-datepicker "^3.1.3"
     styled-system "^5.1.5"
 
-"@admin-bro/mongoose@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@admin-bro/mongoose/-/mongoose-1.1.0.tgz#c83c87bc587d4f46e860851de4c0a1f80a9e3c86"
-  integrity sha512-CMFfN12UV3VE3nZxvZMZK+deCqiU6hPvv6bDLuPzMV0KySPZLoEQe2rHuxgovEDn52bFXP0XPFMDHqW0FiNtfg==
+"@adminjs/mongoose@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@adminjs/mongoose/-/mongoose-2.0.0.tgz#aeaeaba7ecf19e4f66dae2a8f7922d4272336946"
+  integrity sha512-qmgNYdmtKcbZBa69qYOQlYwCtxli7xFhgEn8y2aCry+ECngAcYGmfhcw/izfSnExR49A2AC9MFrAbW987ypcwA==
   dependencies:
     escape-regexp "0.0.1"
     flat "^4.1.0"
@@ -1978,6 +1979,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -2076,6 +2085,25 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/react-redux@^7.1.16":
+  version "7.1.16"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.16.tgz#0fbd04c2500c12105494c83d4a3e45c084e3cb21"
+  integrity sha512-f/FKzIrZwZk7YEO9E1yoxIuDNRiDducxkFlkw/GNMGEnK9n4K8wJzlJBghpSuOVDgEUHoDkDF7Gi9lHNQR4siw==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
+"@types/react@*":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.11.tgz#67fcd0ddbf5a0b083a0f94e926c7d63f3b836451"
+  integrity sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/react@^16.9.16":
   version "16.14.1"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.1.tgz#da2ecb638385614a5573e16e4aa7daf936dbead5"
@@ -2104,6 +2132,11 @@
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/serve-static@*":
   version "1.13.8"
@@ -2254,12 +2287,12 @@ acorn@^7.1.1, acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-admin-bro@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/admin-bro/-/admin-bro-3.3.1.tgz#ef7710310f80b0c945fbb1dff49c6b2359c9a882"
-  integrity sha512-ObdiPDMA8u89U35fwRHxSaje2zBjPqkKlT+6oN80HIRdkQImQ+51hEU5YaQ/EEzWFQGqGYuSxAhkFtXY6ZLjhg==
+adminjs@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/adminjs/-/adminjs-5.0.0.tgz#335021b4cef136efaa8d75e41db43c806a8eee35"
+  integrity sha512-kedIkWX+83XaU9sQAM5TcYUxPNrat1J8cafC4O9gJhz1//bFz53hWCUsLtRhZuDDVvoKXGZ18h7tlbcG5MQJGg==
   dependencies:
-    "@admin-bro/design-system" "^1.7.0"
+    "@adminjs/design-system" "^2.0.0"
     "@babel/core" "^7.10.2"
     "@babel/parser" "^7.10.2"
     "@babel/plugin-transform-runtime" "^7.10.1"
@@ -2274,15 +2307,16 @@ admin-bro@^3.3.1:
     "@rollup/plugin-node-resolve" "^9.0.0"
     "@rollup/plugin-replace" "^2.3.3"
     "@types/react" "^16.9.16"
-    axios "^0.19.2"
+    axios "^0.21.1"
     babel-plugin-styled-components "^1.11.1"
     commander "^5.1.0"
     flat "^4.1.0"
-    i18next "^19.1.0"
+    i18next "19.8.7"
     lodash "^4.17.11"
     ora "^4.0.2"
     prop-types "^15.7.2"
     react "=16.13.1"
+    react-beautiful-dnd "^13.0.0"
     react-dom "=16.13.1"
     react-i18next "^11.3.1"
     react-is "=16.13.1"
@@ -2591,12 +2625,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
-    follow-redirects "1.5.10"
+    follow-redirects "^1.10.0"
 
 babel-jest@^26.6.3:
   version "26.6.3"
@@ -3662,6 +3696,13 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+css-box-model@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
+  dependencies:
+    tiny-invariant "^1.0.6"
+
 css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
@@ -3729,6 +3770,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.15.0.tgz#424de6b3778e4e69d3ff27046ec136af58ae5d5f"
+  integrity sha512-ZCPzAMJZn3rNUvvQIMlXhDr4A+Ar07eLeGsGREoWU19a3Pqf5oYa+ccd+B3F6XVtQY6HANMFdOQ8A+ipFnvJdQ==
+
 date-fns@^2.0.1:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
@@ -3746,7 +3792,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@=3.1.0:
+debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -4789,12 +4835,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
+follow-redirects@^1.10.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
+  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -5268,7 +5312,7 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -5413,10 +5457,10 @@ husky@^4.3.0:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
-i18next@^19.1.0:
-  version "19.8.4"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.8.4.tgz#447718f2a26319b8debdbcc6fbc1a9761be7316b"
-  integrity sha512-FfVPNWv+felJObeZ6DSXZkj9QM1Ivvh7NcFCgA8XPtJWHz0iXVa9BUy+QY8EPrCLE+vWgDfV/sc96BgXVo6HAA==
+i18next@19.8.7:
+  version "19.8.7"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.8.7.tgz#ef023e353974d1b1453e8b6331bd9fb7cba427df"
+  integrity sha512-ezo1gb7QO4OQ5gQCdZMUxopwQSoqpRp6whdEjm1grxMSmkGj1NJ+kYS0UQd4NnpPIVqsgqTQ2L2eqSQYQ+U3Fw==
   dependencies:
     "@babel/runtime" "^7.12.0"
 
@@ -7170,6 +7214,11 @@ memoize-one@^5.0.0:
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
+memoize-one@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 memory-pager@^1.0.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
@@ -8715,6 +8764,11 @@ qw@~1.0.1:
   resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
   integrity sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=
 
+raf-schd@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
 random-bytes@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/random-bytes/-/random-bytes-1.0.0.tgz#4f68a1dc0ae58bd3fb95848c30324db75d64360b"
@@ -8752,6 +8806,19 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-beautiful-dnd@^13.0.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz#ec97c81093593526454b0de69852ae433783844d"
+  integrity sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.2.0"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
+
 react-datepicker@^3.1.3:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-3.3.0.tgz#38dec531fd7c8e0de6860a55dfbc3a8ff803d43c"
@@ -8788,7 +8855,7 @@ react-input-autosize@^2.2.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@=16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
+react-is@=16.13.1, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -8826,6 +8893,18 @@ react-redux@=7.2.0:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"
+
+react-redux@^7.2.0:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.4.tgz#1ebb474032b72d806de2e0519cd07761e222e225"
+  integrity sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    "@types/react-redux" "^7.1.16"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.13.1"
 
 react-router-dom@=5.2.0:
   version "5.2.0"
@@ -9043,6 +9122,13 @@ redux@=4.0.5:
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
+
+redux@^4.0.0, redux@^4.0.4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.0.tgz#eb049679f2f523c379f1aff345c8612f294c88d4"
+  integrity sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
@@ -10359,7 +10445,7 @@ timed-out@^4.0.0:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
-tiny-invariant@^1.0.2:
+tiny-invariant@^1.0.2, tiny-invariant@^1.0.6:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
@@ -10862,6 +10948,11 @@ url-parse-lax@^3.0.0:
   integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
     prepend-http "^2.0.0"
+
+use-memo-one@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.2.tgz#0c8203a329f76e040047a35a1197defe342fab20"
+  integrity sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
This commit is a part of AdminBro to AdminJS rebranding process.

BREAKING CHANGE: AdminBro has been rebranded to AdminJS. All package and repository names had been updated.

# Migration Guide
1. Update your dependencies to use new `adminjs` packages.
- `admin-bro` -> `adminjs` for the core package
- `@admin-bro/<package name>` -> `@adminjs/<package name>` for other modules
2. Update your custom CSS classes:
- `.admin-bro_<component name>` -> `.adminjs_<component name>` (example: `.adminjs_Box`)
3. Search your project for `admin-bro` occurrences - most likely they will have to be updated to `adminjs`