### PR TITLE
fix:err_package_path_not_exported error in typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "require": "./lib/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
![admin express errror](https://github.com/SoftwareBrothers/adminjs-expressjs/assets/46525891/03e27a30-28a8-4336-8080-7ecb2fb5015a)

I fixed the error by adding "require" field to the "exports" field in package.json.