### PR TITLE
fix(Router): allow assets from dotfiles

### DIFF
--- a/src/buildRouter.ts
+++ b/src/buildRouter.ts
@@ -120,7 +120,7 @@ export const buildAssets = ({
 
   assets.forEach((asset) => {
     router.get(asset.path, async (_req, res) => {
-      res.sendFile(path.resolve(asset.src));
+      res.sendFile(path.resolve(asset.src), { dotfiles: "allow" });
     });
   });
 };


### PR DESCRIPTION
Express ignores any files that are stored in directories starting with a dot (`.`). This means that assets stored in the `.adminjs` directory can't be served and so return a 404. 

This PR makes sure that these files are allowed to be retrieved.